### PR TITLE
Fix and improve e-commerce checkout and cart

### DIFF
--- a/test_env.php
+++ b/test_env.php
@@ -1,0 +1,26 @@
+<?php
+
+// Simple environment test
+echo "Environment Test:\n";
+echo "APP_DEBUG: " . (env('APP_DEBUG') ? 'true' : 'false') . "\n";
+echo "RAZORPAY_KEY: " . env('RAZORPAY_KEY') . "\n";
+echo "RAZORPAY_SECRET: " . env('RAZORPAY_SECRET') . "\n";
+
+// Check if .env file exists
+echo ".env file exists: " . (file_exists('.env') ? 'yes' : 'no') . "\n";
+
+// Try reading .env file directly
+if (file_exists('.env')) {
+    $envContent = file_get_contents('.env');
+    echo "RAZORPAY keys in .env file:\n";
+    $lines = explode("\n", $envContent);
+    foreach ($lines as $line) {
+        if (strpos($line, 'RAZORPAY') !== false) {
+            echo "  " . $line . "\n";
+        }
+        if (strpos($line, 'APP_DEBUG') !== false) {
+            echo "  " . $line . "\n";
+        }
+    }
+}
+?>


### PR DESCRIPTION
Fixes "Failed to initialize payment gateway" error in Razorpay checkout.

The `Failed to initialize payment gateway` error occurred because the `$razorpayOrder` variable was not consistently defined across all code paths, leading to a null reference. This PR refactors the `CheckoutController` to ensure proper initialization, adds comprehensive debug logging for Razorpay configuration, and implements robust fallback mechanisms for development environments with placeholder keys.

---

[Open in Web](https://cursor.com/agents?id=bc-d62c56e3-5a91-4cb4-b8b8-3c9663d4c2b9) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-d62c56e3-5a91-4cb4-b8b8-3c9663d4c2b9) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)